### PR TITLE
Add Send + Sync to HathoraTransport to indicate it is threadsafe

### DIFF
--- a/rust-client-sdk/Cargo.lock
+++ b/rust-client-sdk/Cargo.lock
@@ -254,7 +254,7 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hathora-client-sdk"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/rust-client-sdk/src/lib.rs
+++ b/rust-client-sdk/src/lib.rs
@@ -73,7 +73,7 @@ impl HathoraClient {
         token: &str,
         state_id: &str,
         transport_type: HathoraTransportType,
-    ) -> Result<Box<dyn HathoraTransport + Send + Sync>> {
+    ) -> Result<Box<dyn HathoraTransport>> {
         match transport_type {
             HathoraTransportType::WebSocket => {
                 let mut transport = WebsocketTransport::new(
@@ -98,7 +98,7 @@ pub enum HathoraTransportType {
     WebSocket,
 }
 
-pub trait HathoraTransport {
+pub trait HathoraTransport : Send + Sync {
     fn connect(&mut self, state_id: &str, token: &str) -> Result<()>;
 
     fn write_message(&mut self, data: Vec<u8>) -> Result<()>;
@@ -116,7 +116,8 @@ struct WebsocketTransport {
 
 impl WebsocketTransport {
     fn new(app_id: String, coordinator_host: Option<String>) -> WebsocketTransport {
-        let coordinator_host = coordinator_host.unwrap_or_else(|| "coordinator.hathora.dev".to_string());
+        let coordinator_host =
+            coordinator_host.unwrap_or_else(|| "coordinator.hathora.dev".to_string());
         let websocket_url = format!("wss://{}/connect/{}", coordinator_host, app_id);
         let (web_socket, _response) =
             connect(Url::parse(&websocket_url).unwrap()).expect("Can't connect to websocket");

--- a/rust-client-sdk/src/lib.rs
+++ b/rust-client-sdk/src/lib.rs
@@ -73,7 +73,7 @@ impl HathoraClient {
         token: &str,
         state_id: &str,
         transport_type: HathoraTransportType,
-    ) -> Result<Box<dyn HathoraTransport>> {
+    ) -> Result<Box<dyn HathoraTransport + Send>> {
         match transport_type {
             HathoraTransportType::WebSocket => {
                 let mut transport = WebsocketTransport::new(

--- a/rust-client-sdk/src/lib.rs
+++ b/rust-client-sdk/src/lib.rs
@@ -73,7 +73,7 @@ impl HathoraClient {
         token: &str,
         state_id: &str,
         transport_type: HathoraTransportType,
-    ) -> Result<Box<dyn HathoraTransport + Send>> {
+    ) -> Result<Box<dyn HathoraTransport + Send + Sync>> {
         match transport_type {
             HathoraTransportType::WebSocket => {
                 let mut transport = WebsocketTransport::new(


### PR DESCRIPTION
This is necessary to tell bevy that transports can be shared across threads.