### PR TITLE
feature: migrate to LobbyV2 endpoints

### DIFF
--- a/typescript-client-sdk/client.ts
+++ b/typescript-client-sdk/client.ts
@@ -36,32 +36,29 @@ export class HathoraClient {
     return res.token;
   }
 
-  public async createPrivateLobby(token: string): Promise<string> {
-    return await this.postJson(
-      `https://api.hathora.dev/lobby/v1/${this.appId}/create/private?local=${
-        this.localConnectionDetails === undefined ? "false" : "true"
-      }`,
-      {},
+  public async createPrivateLobby(token: string, { region = 'Washington_DC', initialConfig = '{}' } = {}): Promise<string> {
+    const visibility = this.localConnectionDetails !== undefined ? 'local' : 'private'
+    const { roomId } = await this.postJson(
+      `https://api.hathora.dev/lobby/v2/${this.appId}/create`,
+      { visibility, region, initialConfig },
       { Authorization: token }
     );
+    return roomId
   }
 
-  public async createPublicLobby(token: string): Promise<string> {
-    return await this.postJson(
-      `https://api.hathora.dev/lobby/v1/${this.appId}/create/public?local=${
-        this.localConnectionDetails === undefined ? "false" : "true"
-      }`,
-      {},
+  public async createPublicLobby(token: string, { region = 'Washington_DC', initialConfig = '{}' } = {}): Promise<string> {
+    const visibility = this.localConnectionDetails !== undefined ? 'local' : 'public'
+    const { roomId } = await this.postJson(
+      `https://api.hathora.dev/lobby/v2/${this.appId}/create`,
+      { visibility, region, initialConfig },
       { Authorization: token }
     );
+    return roomId
   }
 
-  public async getPublicLobbies(token: string, region?: string): Promise<LobbyInfo[]> {
-    const regionParam = region === undefined ? "" : `region=${region}&`;
+  public async getPublicLobbies(token: string, region = 'Washington_DC'): Promise<LobbyInfo[]> {
     const res = await fetch(
-      `https://api.hathora.dev/lobby/v1/${this.appId}/list?${regionParam}local=${
-        this.localConnectionDetails === undefined ? "false" : "true"
-      }`,
+      `https://api.hathora.dev/lobby/v2/${this.appId}/list/public?region=${region}`,
       { headers: { Authorization: token } }
     );
     return await res.json();

--- a/typescript-client-sdk/client.ts
+++ b/typescript-client-sdk/client.ts
@@ -57,7 +57,7 @@ export class HathoraClient {
   }
 
   public async getPublicLobbies(token: string, region?: string): Promise<LobbyInfo[]> {
-    const regionParam = region === undefined ? "" : `region=${region}`;
+    const regionParam = region === undefined ? "" : `?region=${region}`;
     const res = await fetch(
       `https://api.hathora.dev/lobby/v2/${this.appId}/list/public?${regionParam}`,
       { headers: { Authorization: token } }

--- a/typescript-client-sdk/client.ts
+++ b/typescript-client-sdk/client.ts
@@ -36,7 +36,7 @@ export class HathoraClient {
     return res.token;
   }
 
-  public async createPrivateLobby(token: string, { region = "Washington_DC", initialConfig = "{}" } = {}): Promise<string> {
+  public async createPrivateLobby(token: string, { region = "Washington_DC", initialConfig = {} } = {}): Promise<string> {
     const visibility = this.localConnectionDetails !== undefined ? "local" : "private";
     const { roomId } = await this.postJson(
       `https://api.hathora.dev/lobby/v2/${this.appId}/create`,
@@ -46,7 +46,7 @@ export class HathoraClient {
     return roomId;
   }
 
-  public async createPublicLobby(token: string, { region = "Washington_DC", initialConfig = "{}" } = {}): Promise<string> {
+  public async createPublicLobby(token: string, { region = "Washington_DC", initialConfig = {} } = {}): Promise<string> {
     const visibility = this.localConnectionDetails !== undefined ? "local" : "public";
     const { roomId } = await this.postJson(
       `https://api.hathora.dev/lobby/v2/${this.appId}/create`,

--- a/typescript-client-sdk/client.ts
+++ b/typescript-client-sdk/client.ts
@@ -36,27 +36,27 @@ export class HathoraClient {
     return res.token;
   }
 
-  public async createPrivateLobby(token: string, { region = 'Washington_DC', initialConfig = '{}' } = {}): Promise<string> {
-    const visibility = this.localConnectionDetails !== undefined ? 'local' : 'private'
+  public async createPrivateLobby(token: string, { region = "Washington_DC", initialConfig = "{}" } = {}): Promise<string> {
+    const visibility = this.localConnectionDetails !== undefined ? "local" : "private";
     const { roomId } = await this.postJson(
       `https://api.hathora.dev/lobby/v2/${this.appId}/create`,
       { visibility, region, initialConfig },
       { Authorization: token }
     );
-    return roomId
+    return roomId;
   }
 
-  public async createPublicLobby(token: string, { region = 'Washington_DC', initialConfig = '{}' } = {}): Promise<string> {
-    const visibility = this.localConnectionDetails !== undefined ? 'local' : 'public'
+  public async createPublicLobby(token: string, { region = "Washington_DC", initialConfig = "{}" } = {}): Promise<string> {
+    const visibility = this.localConnectionDetails !== undefined ? "local" : "public";
     const { roomId } = await this.postJson(
       `https://api.hathora.dev/lobby/v2/${this.appId}/create`,
       { visibility, region, initialConfig },
       { Authorization: token }
     );
-    return roomId
+    return roomId;
   }
 
-  public async getPublicLobbies(token: string, region = 'Washington_DC'): Promise<LobbyInfo[]> {
+  public async getPublicLobbies(token: string, region = ""): Promise<LobbyInfo[]> {
     const res = await fetch(
       `https://api.hathora.dev/lobby/v2/${this.appId}/list/public?region=${region}`,
       { headers: { Authorization: token } }

--- a/typescript-client-sdk/client.ts
+++ b/typescript-client-sdk/client.ts
@@ -59,7 +59,7 @@ export class HathoraClient {
   public async getPublicLobbies(token: string, region?: string): Promise<LobbyInfo[]> {
     const regionParam = region === undefined ? "" : `?region=${region}`;
     const res = await fetch(
-      `https://api.hathora.dev/lobby/v2/${this.appId}/list/public?${regionParam}`,
+      `https://api.hathora.dev/lobby/v2/${this.appId}/list/public${regionParam}`,
       { headers: { Authorization: token } }
     );
     return await res.json();

--- a/typescript-client-sdk/client.ts
+++ b/typescript-client-sdk/client.ts
@@ -56,9 +56,10 @@ export class HathoraClient {
     return roomId;
   }
 
-  public async getPublicLobbies(token: string, region = ""): Promise<LobbyInfo[]> {
+  public async getPublicLobbies(token: string, region?: string): Promise<LobbyInfo[]> {
+    const regionParam = region === undefined ? "" : `region=${region}`;
     const res = await fetch(
-      `https://api.hathora.dev/lobby/v2/${this.appId}/list/public?region=${region}`,
+      `https://api.hathora.dev/lobby/v2/${this.appId}/list/public?${regionParam}`,
       { headers: { Authorization: token } }
     );
     return await res.json();


### PR DESCRIPTION
This migrates off of deprecated LobbyV1 endpoints, and onto LobbyV2 endpoints.

Since `region` is required, and I was hesitant to change the method's signature... so to ease backward compatibility, I arbitrarily picked `Washington_DC`. It feels a little smelly, so perhaps in the future it would be possible to make this optional, and allow the server to pick one at runtime based on a setting from the Hathora console, or from ping, or something.

### Testing

I tested this by building locally. From a local checkout of this repo to `~/work/buildkits`, and then:

```bash
cd typescript-client-sdk
npm run build
```

Then on a local checkout of [builder](https://github.com/hathora/builder) to `~/work/builder`, I changed the dependency:
```patch
-    "@hathora/client-sdk": "^1.1.0",
+    "@hathora/client-sdk": "file://~/work/buildkits/typescript-client-sdk",
```

Then from the root of a Hathora game, I ran

```bash
ts-node ~/work/builder/src/cli.ts dev
```